### PR TITLE
update: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ USER node
 
 # Install dependencies
 COPY package.json yarn.* ./
-RUN yarn
+RUN yarn --network-timeout 1000000 
 
 # Copy app source
 COPY --chown=node:node . .


### PR DESCRIPTION
Set the following flag for yarn: --network-timeout 1000000
The reason is that yarn often timeouts during multi-arch builds,
stopping the entire CI, even if other parallel builds have succeeded.
So setting a bigger timeout might solve fix this problem.